### PR TITLE
Enable marks overlap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@collaborne/y-prosemirror",
-  "version": "1.2.2",
+  "version": "1.2.3-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@collaborne/y-prosemirror",
-      "version": "1.2.2",
+      "version": "1.2.3-0",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.34"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@collaborne/y-prosemirror",
-  "version": "1.2.2",
+  "version": "1.2.3-0",
   "description": "Prosemirror bindings for Yjs",
   "main": "./dist/y-prosemirror.cjs",
   "module": "./src/y-prosemirror.js",

--- a/src/lib.js
+++ b/src/lib.js
@@ -269,18 +269,35 @@ export function yDocToProsemirrorJSON (
         }
 
         if (d.attributes) {
-          text.marks = Object.keys(d.attributes).map((type) => {
-            const attrs = d.attributes[type]
-            const mark = {
-              type
-            }
+          let marks = []
+          text.marks = Object.keys(d.attributes).forEach((type) => {
+            let attrs = d.attributes[type]
+            if (Array.isArray(attrs)) {
+              // multiple marks of same type
+              attrs.forEach(singleAttrs => {
+                const mark = {
+                  type
+                }
 
-            if (Object.keys(attrs)) {
-              mark.attrs = attrs
-            }
+                if (Object.keys(singleAttrs)) {
+                  mark.attrs = singleAttrs
+                }
 
-            return mark
+                marks.push(mark)
+              })
+            } else {
+              const mark = {
+                type
+              }
+
+              if (Object.keys(attrs)) {
+                mark.attrs = attrs
+              }
+
+              marks.push(mark)
+            }
           })
+          text.marks = marks
         }
         return text
       })

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -497,7 +497,15 @@ const createTextNodesFromYText = (text, schema, mapping, snapshot, prevSnapshot,
       const delta = deltas[i]
       const marks = []
       for (const markName in delta.attributes) {
-        marks.push(schema.mark(markName, delta.attributes[markName]))
+        if (Array.isArray(delta.attributes[markName])) {
+          // multiple marks of same type
+          delta.attributes[markName].forEach(attrs => {
+            marks.push(schema.mark(markName, attrs))
+          })
+        } else {
+          // single mark
+          marks.push(schema.mark(markName, delta.attributes[markName]))
+        }
       }
       nodes.push(schema.text(delta.insert, marks))
     }
@@ -569,6 +577,14 @@ const equalAttrs = (pattrs, yattrs) => {
   return eq
 }
 
+const containsEqualMark = (pattrs, yattrs) => {
+  if (Array.isArray(yattrs)) {
+    return !!yattrs.find(el => equalAttrs(pattrs, el))
+  } else {
+    return equalAttrs(pattrs, yattrs)
+  }
+}
+
 /**
  * @typedef {Array<Array<PModel.Node>|PModel.Node>} NormalizedPNodeContent
  */
@@ -595,15 +611,24 @@ const normalizePNodeContent = pnode => {
   }
   return res
 }
-
+const countYTextMarks = (yattrs) => {
+  let count = 0
+  object.forEach(yattrs, (val) => {
+    if (Array.isArray(val)) {
+      count += val.length
+    } else {
+      count++
+    }
+  })
+  return count
+}
 /**
  * @param {Y.XmlText} ytext
  * @param {Array<any>} ptexts
  */
 const equalYTextPText = (ytext, ptexts) => {
   const delta = ytext.toDelta()
-  return delta.length === ptexts.length && delta.every((d, i) => d.insert === /** @type {any} */ (ptexts[i]).text && object.keys(d.attributes || {}).length === ptexts[i].marks.length && ptexts[i].marks.every(mark => equalAttrs(d.attributes[mark.type.name] || {}, mark.attrs)))
-}
+  return delta.length === ptexts.length && delta.every((d, i) => d.insert === /** @type {any} */ (ptexts[i]).text && countYTextMarks(d.attributes || {}) === ptexts[i].marks.length && ptexts[i].marks.every(mark => containsEqualMark(d.attributes[mark.type.name] || {}, mark.attrs)))}
 
 /**
  * @param {Y.XmlElement|Y.XmlText|Y.XmlHook} ytype
@@ -706,7 +731,16 @@ const marksToAttributes = marks => {
   const pattrs = {}
   marks.forEach(mark => {
     if (mark.type.name !== 'ychange') {
-      pattrs[mark.type.name] = mark.attrs
+      if (pattrs[mark.type.name] && Array.isArray(pattrs[mark.type.name])) {
+        // already has multiple marks of same type
+        pattrs[mark.type.name].push(mark.attrs)
+      } else if (pattrs[mark.type.name]) {
+        // already has mark of same type, change to array
+        pattrs[mark.type.name] = [pattrs[mark.type.name], mark.attrs]
+      } else {
+        // first mark of this type
+        pattrs[mark.type.name] = mark.attrs
+      }
     }
   })
   return pattrs

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -628,7 +628,8 @@ const countYTextMarks = (yattrs) => {
  */
 const equalYTextPText = (ytext, ptexts) => {
   const delta = ytext.toDelta()
-  return delta.length === ptexts.length && delta.every((d, i) => d.insert === /** @type {any} */ (ptexts[i]).text && countYTextMarks(d.attributes || {}) === ptexts[i].marks.length && ptexts[i].marks.every(mark => containsEqualMark(d.attributes[mark.type.name] || {}, mark.attrs)))}
+  return delta.length === ptexts.length && delta.every((d, i) => d.insert === /** @type {any} */ (ptexts[i]).text && countYTextMarks(d.attributes || {}) === ptexts[i].marks.length && ptexts[i].marks.every(mark => containsEqualMark(d.attributes[mark.type.name] || {}, mark.attrs)))
+}
 
 /**
  * @param {Y.XmlElement|Y.XmlText|Y.XmlHook} ytype

--- a/test/complexSchema.js
+++ b/test/complexSchema.js
@@ -157,6 +157,7 @@ export const nodes = {
 const emDOM = ['em', 0]
 const strongDOM = ['strong', 0]
 const codeDOM = ['code', 0]
+const entityReferenceDOM = ['span', 0]
 
 // :: Object [Specs](#model.MarkSpec) for the marks in the schema.
 export const marks = {
@@ -221,6 +222,16 @@ export const marks = {
     parseDOM: [{ tag: 'code' }],
     toDOM () {
       return codeDOM
+    }
+  },
+  entityReference: {
+    attrs: {
+      id: { default: null }
+    },
+    exclude: '', // allow multiple "entityReferences" marks to overlap
+    parseDOM: [{ tag: 'span' }],
+    toDOM () {
+      return entityReferenceDOM
     }
   },
   ychange: {


### PR DESCRIPTION
In Collab editing `SyncPlugin` does not allow for overlapping marks with the same type and different attributes (like prosemirror does). 

This PR allows for overlapping marks to be shared via `SyncPlugin`.

This PR is a copy of https://github.com/YousefED/y-prosemirror/tree/overlapping-marks (can't merge it directly for version compatibility reasons). 

Fixes: https://github.com/orgs/Collaborne/projects/14

Current missing parts"
https://github.com/yjs/y-prosemirror/pull/52#issue-915348248